### PR TITLE
- Using regex matcher instead of matcher in build route.

### DIFF
--- a/vulcand.go
+++ b/vulcand.go
@@ -387,7 +387,7 @@ func buildVulcanRoute(meta *Metadata) string {
 		regexMatcher := matcher + "Regexp"
 		key = LabelKeyf(regexMatcher)
 		if val, ok := meta.Annotations[key]; ok {
-			bit := fmt.Sprintf("%s(`%s`)", strings.Title(matcher), val)
+			bit := fmt.Sprintf("%s(`%s`)", strings.Title(regexMatcher), val)
 			bits = append(bits, bit)
 		}
 	}


### PR DESCRIPTION
I found a bug when trying to use regexp's on service. This pull requests fixes the issue.